### PR TITLE
clear python vars on each run

### DIFF
--- a/frontend/src/routes/CollabPage.jsx
+++ b/frontend/src/routes/CollabPage.jsx
@@ -1,11 +1,16 @@
-import React, { useEffect, useRef, useState } from 'react';
-import CodeMirror from "@uiw/react-codemirror";
+import { python } from '@codemirror/lang-python';
 import { vscodeDark } from "@uiw/codemirror-theme-vscode";
-import { python } from '@codemirror/lang-python'; 
+import CodeMirror from "@uiw/react-codemirror";
+import React, { useEffect, useState } from 'react';
 // import { loadPyodide } from 'pyodide';
 import { toast } from 'react-toastify';
 import Navbar from '../component/navigation/NavBar';
 import './CollabPage.css';
+
+const CLEAR_INTERPRETER = `
+globals().clear()
+
+`
 
 function CollabPage() {
 
@@ -35,7 +40,7 @@ function CollabPage() {
             // Clear previous output
             setOutput('');
             try {
-                const result = pyodide.runPython(code); // Run Python code
+                const result = pyodide.runPython(CLEAR_INTERPRETER + code); // Run Python code
                 if (result) {
                     setOutput(prevOutput => prevOutput + result); // Append result if there is one
                 }


### PR DESCRIPTION
Pyodide stores python vars from previous runs (like python notebooks). Clear variables from prev run

![Screenshot 2024-10-24 at 12 28 21 PM](https://github.com/user-attachments/assets/23b62b0b-51f4-44ac-9835-d2c990cbc7e5)
